### PR TITLE
Build: revert makefile to f61c098 + update osx travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
     - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then sudo apt-get -y install libboost-{chrono,log,program-options,date-time,thread,system,filesystem,regex,test}1.58{-dev,.0}; fi
 
     - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then brew upgrade boost; fi
-    - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then brew install cryptopp openssl miniupnpc doxygen; fi
+    - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then brew install openssl miniupnpc doxygen graphviz; fi
 
 before_script:
     - if [ "$CC" = "gcc" ]; then export CC=gcc-${GCC_VERSION}; fi

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ cmake-debug = -D CMAKE_BUILD_TYPE=Debug
 #cmake-release = -D CMAKE_BUILD_TYPE=Release
 
 # Our base cmake command
-cmake = cmake $(cmake-gen) $(cmake-debug)
+cmake = cmake $(cmake-gen) $(cmake-debug) -D CMAKE_C_COMPILER=$(CC) -D CMAKE_CXX_COMPILER=$(CXX)
 
 # Dependencies options
 cmake-cpp-netlib = -D CPP-NETLIB_BUILD_TESTS=OFF -D CPP-NETLIB_BUILD_EXAMPLES=OFF


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- I have read and understood the [contributor guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull request may be closed by the will of the maintainer.
- I give this submission freely and claim no ownership to its content.

_Place an X inside the bracket to confirm_
- [X] I confirm.

---
- Taking out CMAKE_C*_COMPILER will only require having to issue
  make clean between builds with different compilers when building
  on in-house machines (and it has nothing to do with the OSX build)
- Updated dependencies for OSX on Travis:
  - We shouldn't need the cryptopp package
    (cryptopp is built as a submodule off branch 0.13-release)
  - Added graphviz
